### PR TITLE
Improve cookbook description to make it more discoverable.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -2,6 +2,6 @@ maintainer 'CustomInk, LLC'
 name 'magic_shell'
 maintainer_email 'webops@customink.com'
 license 'Apache 2.0'
-description 'Installs/Configures command_alias'
+description 'Creates system-global environment variables and shell command aliases'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '1.0.1'


### PR DESCRIPTION
This cookbook is quite handy, but is almost impossible to find with its current name and description. I’ve updated the metadata.rb description here, so that at least it will show up on searches for “environment variables” and “aliases” on the Chef community site. I suggest also updating the GitHub repo description accordingly.

Not sure what the practicalities of renaming a cookbook are, but if it’s doable, I’d also suggest renaming the cookbook to something like ‘system_environment’.
