### PR TITLE
Add optional filename attribute to the environment lwrp

### DIFF
--- a/providers/environment.rb
+++ b/providers/environment.rb
@@ -64,5 +64,9 @@ def destination
 end
 
 def filename
-  new_resource.environment_variable.to_s.gsub(/\s/, '_')
+  if new_resource.filename.nil?
+    new_resource.environment_variable.to_s.gsub(/\s/, '_')
+  else
+    new_resource.filename.to_s.gsub(/\s/, '_')
+  end
 end

--- a/resources/environment.rb
+++ b/resources/environment.rb
@@ -25,6 +25,7 @@ default_action :add
 
 attribute :environment_variable, kind_of: String, name_attribute: true
 attribute :value,                kind_of: String
+attribute :filename,             kind_of: String, default: nil
 attribute :owner,                kind_of: String, default: 'root'
 attribute :group,                kind_of: String, default: 'root'
 attribute :mode,                 kind_of: String, default: '0644'

--- a/test/fixtures/cookbooks/magic_shell_environment/recipes/add.rb
+++ b/test/fixtures/cookbooks/magic_shell_environment/recipes/add.rb
@@ -1,3 +1,8 @@
 magic_shell_environment 'RAILS_ENV' do
   value 'production'
 end
+
+magic_shell_environment 'PATH' do
+  filename 'NODE_ENV'
+  value '/usr/local/node-binary/bin:$PATH'
+end

--- a/test/fixtures/cookbooks/magic_shell_environment/recipes/remove.rb
+++ b/test/fixtures/cookbooks/magic_shell_environment/recipes/remove.rb
@@ -3,3 +3,8 @@ include_recipe 'magic_shell_environment::add'
 magic_shell_environment 'RAILS_ENV' do
   action :remove
 end
+
+magic_shell_environment 'PATH' do
+  action :remove
+  filename 'NODE_ENV'
+end

--- a/test/integration/magic_shell_environment_add/serverspec/assert_added_spec.rb
+++ b/test/integration/magic_shell_environment_add/serverspec/assert_added_spec.rb
@@ -4,3 +4,8 @@ describe file('/etc/profile.d/RAILS_ENV.sh') do
   it { should be_file }
   its(:content) { should include('export RAILS_ENV="production"') }
 end
+
+describe file('/etc/profile.d/NODE_ENV.sh') do
+  it { should be_file }
+  its(:content) { should include('export PATH="/usr/local/node-binary/bin:$PATH"') }
+end

--- a/test/integration/magic_shell_environment_remove/serverspec/assert_removed_spec.rb
+++ b/test/integration/magic_shell_environment_remove/serverspec/assert_removed_spec.rb
@@ -3,3 +3,7 @@ require_relative '../../../kitchen/data/spec_helper'
 describe file('/etc/profile.d/RAILS_ENV.sh') do
   it { should_not be_file }
 end
+
+describe file('/etc/profile.d/NODE_ENV.sh') do
+  it { should_not be_file }
+end


### PR DESCRIPTION
You sometimes need to modify the same environment variable in multiple places. For example the PATH might be modified by multiple recipes. Currently the filename added to /etc/profile.d is the same as the variable name which means that later editings of the variable will override the previous ones.

This patch adds an optional filename attribute to the LWRP which allows you to specify the profile.d filename. This way you can edit the same variable multiple times. By default the filename will remain the same as the variable name, maintaining backwards compatibility.
